### PR TITLE
DRAFT: feat: referenced and primary keys

### DIFF
--- a/fabrique-core/src/lib.rs
+++ b/fabrique-core/src/lib.rs
@@ -35,8 +35,8 @@ pub trait Persistable: Sized {
     ///
     /// This method should handle the actual database insertion or persistence logic
     /// and return the created object with any auto-generated fields (like IDs) populated.
-    fn create(
+    fn create<'a>(
         self,
-        connection: &Self::Connection,
-    ) -> impl Future<Output = Result<Self, Self::Error>>;
+        connection: &'a Self::Connection,
+    ) -> impl Future<Output = Result<Self, Self::Error>> + 'a;
 }

--- a/fabrique-derive/Cargo.toml
+++ b/fabrique-derive/Cargo.toml
@@ -15,5 +15,5 @@ proc-macro = true
 fabrique-core = { path = "../fabrique-core", version = "0.1.0" }
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "2.0", features = ["extra-traits"] }
+syn = { version = "2.0", features = ["extra-traits", "full"] }
 thiserror = "2.0"

--- a/fabrique-derive/src/analysis.rs
+++ b/fabrique-derive/src/analysis.rs
@@ -1,7 +1,7 @@
 use quote::ToTokens;
 use syn::{
-    Data, DataStruct, DeriveInput, Expr, ExprLit, Field, Fields, FieldsNamed, Ident, Lit, LitStr,
-    Meta, punctuated::Punctuated, spanned::Spanned, token::Comma,
+    Data, DataStruct, DeriveInput, Expr, ExprAssign, ExprLit, Field, Fields, FieldsNamed, Ident,
+    Lit, LitBool, Meta, MetaNameValue, Token, punctuated::Punctuated, spanned::Spanned,
 };
 
 use crate::error::Error;
@@ -11,6 +11,161 @@ use crate::error::Error;
 /// Only supports structs with named fields.
 pub struct FactoryAnalysis {
     input: DeriveInput,
+}
+
+#[derive(Default, Debug)]
+pub struct FabriqueFieldAttributes {
+    primary_key: bool,
+    relation: Option<Ident>,
+    referenced_key: Option<Ident>,
+}
+
+impl FabriqueFieldAttributes {
+    pub fn from_field(field: &Field) -> Result<FabriqueFieldAttributes, Error> {
+        let mut result = Self::default();
+
+        for attribute in field
+            .attrs
+            .iter()
+            .filter(|attr| attr.path().is_ident("fabrique"))
+        {
+            match attribute.meta {
+                Meta::NameValue(ref name_value) => {
+                    result.parse_name_value(name_value)?;
+                }
+                Meta::List(ref list) => {
+                    match list.parse_args_with(Punctuated::<Expr, Token![,]>::parse_terminated) {
+                        Ok(exprs) => {
+                            for expr in exprs {
+                                match expr {
+                                    Expr::Assign(ExprAssign {
+                                        left,
+                                        eq_token,
+                                        right,
+                                        ..
+                                    }) => match *left {
+                                        Expr::Path(ref path) => {
+                                            result.parse_name_value(&MetaNameValue {
+                                                path: path.path.clone(),
+                                                eq_token,
+                                                value: *right,
+                                            })?;
+                                        }
+                                        _ => {
+                                            return Err(Error::UnparsableAttribute(
+                                                attribute.to_token_stream().to_string(),
+                                            ));
+                                        }
+                                    },
+                                    Expr::Path(ref path) => {
+                                        result.parse_name_value(&MetaNameValue {
+                                            path: path.path.clone(),
+                                            eq_token: Token![=](path.span()),
+                                            value: Expr::Lit(ExprLit {
+                                                lit: Lit::Bool(LitBool {
+                                                    value: true,
+                                                    span: path.span(),
+                                                }),
+                                                attrs: vec![],
+                                            }),
+                                        })?;
+                                    }
+                                    _ => {
+                                        return Err(Error::UnparsableAttribute(
+                                            attribute.to_token_stream().to_string(),
+                                        ));
+                                    }
+                                }
+                            }
+                        }
+                        Err(_) => {
+                            return Err(Error::UnparsableAttribute(
+                                attribute.to_token_stream().to_string(),
+                            ));
+                        }
+                    }
+                }
+                Meta::Path(ref path) => {
+                    println!("{path:?}");
+                    return Err(Error::UnparsableAttribute(
+                        attribute.to_token_stream().to_string(),
+                    ));
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    fn parse_name_value(&mut self, name_value: &MetaNameValue) -> Result<(), Error> {
+        if name_value.path.is_ident("primary_key") {
+            match name_value.value {
+                Expr::Lit(ExprLit {
+                    lit: Lit::Bool(LitBool { value: true, .. }),
+                    ..
+                }) => self.primary_key = true,
+
+                Expr::Lit(ExprLit {
+                    lit: Lit::Str(ref str),
+                    ..
+                }) => {
+                    if let Ok(primary_key) = str.value().parse::<bool>() {
+                        self.primary_key = primary_key;
+                    } else {
+                        return Err(Error::UnparsableLiteral(str.value()));
+                    }
+                }
+                _ => {
+                    return Err(Error::UnparsableLiteral(
+                        name_value.value.to_token_stream().to_string(),
+                    ));
+                }
+            }
+        } else if name_value.path.is_ident("relation") {
+            match name_value.value {
+                Expr::Lit(ExprLit {
+                    lit: Lit::Str(ref str),
+                    ..
+                }) => {
+                    let mut ident = syn::parse_str::<Ident>(&str.value())
+                        .map_err(|_| Error::UnparsableType(str.value()))?;
+                    ident.set_span(str.span());
+                    self.relation = Some(ident);
+                }
+                Expr::Path(ref path) => self.relation = path.path.get_ident().cloned(),
+                _ => {
+                    return Err(Error::UnparsableType(
+                        name_value.value.to_token_stream().to_string(),
+                    ));
+                }
+            }
+        } else if name_value.path.is_ident("referenced_key") {
+            match name_value.value {
+                Expr::Lit(ExprLit {
+                    lit: Lit::Str(ref str),
+                    ..
+                }) => {
+                    self.referenced_key = Some(Ident::new(&str.value(), str.span()));
+                }
+                Expr::Path(ref path) => self.referenced_key = path.path.get_ident().cloned(),
+                _ => {
+                    return Err(Error::UnparsableType(
+                        name_value.value.to_token_stream().to_string(),
+                    ));
+                }
+            }
+        } else {
+            return Err(Error::UnknownAttribute(
+                name_value
+                    .path
+                    .get_ident()
+                    .map(|ident| ident.to_string())
+                    .unwrap_or("".to_string()),
+            ));
+        }
+
+        Ok(())
+    }
 }
 
 impl FactoryAnalysis {
@@ -23,8 +178,7 @@ impl FactoryAnalysis {
     pub fn analyze(self) -> Result<FactoryAnalysisOutput, Error> {
         Ok(FactoryAnalysisOutput {
             base_struct_ident: self.input.ident.clone(),
-            fields: self.fields()?.clone(),
-            relations: self.relations()?,
+            fields: self.fields()?,
         })
     }
 
@@ -33,8 +187,8 @@ impl FactoryAnalysis {
     /// # Errors
     ///
     /// Returns an error for enums, unions, unit structs, or tuple structs.
-    fn fields(&self) -> Result<&Punctuated<Field, Comma>, Error> {
-        match &self.input.data {
+    fn fields(&self) -> Result<Vec<FactoryFieldAnalysisOutput>, Error> {
+        let fields = match &self.input.data {
             Data::Struct(DataStruct {
                 fields: Fields::Named(FieldsNamed { named, .. }),
                 ..
@@ -49,37 +203,20 @@ impl FactoryAnalysis {
             }) => Err(Error::UnsupportedDataStructureTupleStruct),
             Data::Enum(_) => Err(Error::UnsupportedDataStructureEnum),
             Data::Union(_) => Err(Error::UnsupportedDataStructureUnion),
-        }
-    }
+        }?;
 
-    /// Extracts factory relations from field attributes.
-    ///
-    /// Relations allow linking factories together for creating instances with
-    /// related dependencies, enabling cleaner bootstrapping of complex object graphs.
-    fn relations(&self) -> Result<Vec<Relation>, Error> {
-        self.fields()?
-            .iter()
-            .filter_map(|field| {
-                for attr in &field.attrs {
-                    if attr.path().is_ident("factory")
-                        && let Ok(Meta::NameValue(name_value)) = attr.parse_args::<Meta>()
-                        && name_value.path.is_ident("relation")
-                    {
-                        if let Expr::Lit(ExprLit {
-                            lit: Lit::Str(lit_str),
-                            ..
-                        }) = name_value.value
-                        {
-                            return Some(Relation::new(field, lit_str));
-                        } else {
-                            let value = name_value.value.to_token_stream().to_string();
-                            return Some(Err(Error::UnparsableLiteral(value)));
-                        }
-                    }
-                }
-                None
+        fields
+            .into_iter()
+            .map(|field| -> Result<FactoryFieldAnalysisOutput, Error> {
+                let attributes = FabriqueFieldAttributes::from_field(field)?;
+
+                Ok(FactoryFieldAnalysisOutput {
+                    field: field.clone(),
+                    primary_key: attributes.primary_key,
+                    relation: Relation::new(field, attributes)?,
+                })
             })
-            .collect()
+            .collect::<Result<Vec<FactoryFieldAnalysisOutput>, Error>>()
     }
 }
 
@@ -89,19 +226,37 @@ pub struct FactoryAnalysisOutput {
     /// The identifier of the original struct
     pub base_struct_ident: Ident,
     /// All named fields from the struct
-    pub fields: Punctuated<Field, Comma>,
-    /// Extracted factory relations from field attributes
-    pub relations: Vec<Relation>,
+    pub fields: Vec<FactoryFieldAnalysisOutput>,
+}
+
+impl FactoryAnalysisOutput {
+    pub fn relations(&self) -> impl Iterator<Item = (&Field, &Relation)> {
+        self.fields.iter().filter_map(|field| {
+            field
+                .relation
+                .as_ref()
+                .map(|relation| (&field.field, relation))
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FactoryFieldAnalysisOutput {
+    pub field: Field,
+    #[allow(dead_code)]
+    pub primary_key: bool,
+    pub relation: Option<Relation>,
 }
 
 /// Represents a factory relation extracted from struct field attributes.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Relation {
-    pub field: Field,
     /// The identifier for the factory field (e.g., `anvil_factory`)
-    pub ident: Ident,
-    /// The type of the related factory (e.g., `AnvilFactory`)
-    pub ty: Ident,
+    pub factory_field: Ident,
+    /// The type of the referenced object (e.g., `Anvil`)
+    pub referenced_type: Ident,
+    /// The field of the referenced object referenced by this relation (e.g. `id`)
+    pub referenced_key: Ident,
     /// The base name of the relation (e.g., `anvil`)
     pub name: String,
 }
@@ -111,7 +266,13 @@ impl Relation {
     ///
     /// Automatically derives the relation name by stripping the `_id` suffix
     /// from the field name if present.
-    pub fn new(field: &Field, ty: LitStr) -> Result<Self, Error> {
+    pub fn new(field: &Field, attributes: FabriqueFieldAttributes) -> Result<Option<Self>, Error> {
+        if attributes.relation.is_none() {
+            return Ok(None);
+        }
+
+        let referenced_type = attributes.relation.unwrap();
+
         let field = field.clone();
 
         let field_name = field
@@ -120,21 +281,26 @@ impl Relation {
             .ok_or(Error::UnsupportedDataStructureTupleStruct)?
             .to_string();
 
+        let referenced_key = attributes
+            .referenced_key
+            .or(field_name
+                .rsplit_once("_")
+                .map(|(_, suffix)| Ident::new(suffix, field.span())))
+            .ok_or(Error::MissingReferencedKey(field_name.clone()))?;
+
         let name = field_name
-            .strip_suffix("_id")
+            .strip_suffix(&format!("_{}", referenced_key))
             .unwrap_or(&field_name)
             .to_owned();
 
         let ident = Ident::new(&format!("{}_factory", &name), field.span());
 
-        let ty = syn::parse_str(&ty.value()).map_err(|_| Error::UnparsableType(ty.value()))?;
-
-        Ok(Self {
-            field,
-            ident,
+        Ok(Some(Self {
+            factory_field: ident,
+            referenced_type,
+            referenced_key,
             name,
-            ty,
-        })
+        }))
     }
 }
 
@@ -148,8 +314,10 @@ mod tests {
         // Arrange the analysis
         let analysis = FactoryAnalysis::from(parse_quote! {
             struct Anvil {
+                #[fabrique(primary_key)]
+                id: u32,
                 weight: u32,
-                #[factory(relation = "HammerFactory")]
+                #[fabrique(relation = "Hammer")]
                 hammer_id: u32,
             }
         });
@@ -159,32 +327,55 @@ mod tests {
 
         // Assert the result
         assert!(result.is_ok());
+        let result = result.unwrap();
+        assert_eq!(result.base_struct_ident.to_string(), "Anvil");
+        assert_eq!(result.fields.len(), 3);
+
+        assert!(result.fields.iter().any(|field| {
+            if field.field.ident.as_ref().unwrap() != "id" {
+                return false;
+            }
+
+            assert!(field.primary_key);
+            assert!(field.relation.is_none());
+
+            true
+        }));
+
+        assert!(result.fields.iter().any(|field| {
+            if field.field.ident.as_ref().unwrap() != "weight" {
+                return false;
+            }
+
+            assert!(!field.primary_key);
+            assert!(field.relation.is_none());
+
+            true
+        }));
+
+        assert!(result.fields.iter().any(|field| {
+            if field.field.ident.as_ref().unwrap() != "hammer_id" {
+                return false;
+            }
+
+            assert!(!field.primary_key);
+            assert!(field.relation.is_some());
+            let relation = field.relation.as_ref().unwrap();
+            assert_eq!(relation.factory_field.to_string(), "hammer_factory");
+            assert_eq!(relation.referenced_type.to_string(), "Hammer");
+            assert_eq!(relation.referenced_key.to_string(), "id");
+            assert_eq!(relation.name, "hammer");
+
+            true
+        }));
     }
 
     #[test]
-    fn test_analyze_fails_explicitly_on_fields() {
-        // Arrange the analysis
-        let analysis = FactoryAnalysis::from(parse_quote! {
-            struct Anvil;
-        });
-
-        // Act the call to the analyze method
-        let result = analysis.analyze();
-
-        // Assert the result
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err(),
-            Error::UnsupportedDataStructureUnitStruct
-        );
-    }
-
-    #[test]
-    fn test_analyze_fails_explicitly_on_relations() {
+    fn test_analyze_fails_explicitly_on_unknown_attribute() {
         // Arrange the analysis
         let analysis = FactoryAnalysis::from(parse_quote! {
             struct Anvil {
-                #[factory(relation=true)]
+                #[fabrique(unknown = true)]
                 weight: u32,
             }
         });
@@ -196,19 +387,40 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err(),
-            Error::UnparsableLiteral("true".to_owned())
+            Error::UnknownAttribute("unknown".to_owned())
         );
     }
 
     #[test]
-    fn test_the_relations_method_handles_none() {
+    fn test_analyze_fails_explicitly_on_invalid_relation_attribute() {
+        // Arrange the analysis
+        let analysis = FactoryAnalysis::from(parse_quote! {
+            struct Anvil {
+                #[fabrique(relation=true)]
+                weight: u32,
+            }
+        });
+
+        // Act the call to the analyze method
+        let result = analysis.analyze();
+
+        // Assert the result
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err(),
+            Error::UnparsableType("true".to_owned())
+        );
+    }
+
+    #[test]
+    fn test_the_fields_method_handles_no_relations() {
         // Arrange the analysis
         let analysis = FactoryAnalysis::from(parse_quote! {
             struct Anvil {}
         });
 
         // Act the call to the analyze method
-        let result = analysis.relations();
+        let result = analysis.fields();
 
         // Assert the result
         assert!(result.is_ok());
@@ -216,17 +428,17 @@ mod tests {
     }
 
     #[test]
-    fn test_the_relations_method_handles_some() {
+    fn test_the_fields_method_handles_some_relations() {
         // Arrange the analysis
         let analysis = FactoryAnalysis::from(parse_quote! {
             struct Anvil {
-                #[factory(relation = "HammerFactory")]
+                #[fabrique(relation = "Hammer")]
                 hammer_id: u32,
             }
         });
 
         // Act the call to the analyze method
-        let result = analysis.relations();
+        let result = analysis.fields();
 
         // Assert the result
         assert!(result.is_ok());
@@ -234,86 +446,108 @@ mod tests {
     }
 
     #[test]
-    fn test_the_relations_method_fails_explicitly_on_invalid_fields() {
+    fn test_the_fields_method_fails_explicitely_on_no_referenced_key() {
         // Arrange the analysis
         let analysis = FactoryAnalysis::from(parse_quote! {
-            struct Anvil;
+            struct Anvil {
+                #[fabrique(relation = "Hammer")]
+                hammer: u32,
+            }
         });
 
         // Act the call to the analyze method
-        let result = analysis.relations();
+        let result = analysis.fields();
 
         // Assert the result
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err(),
-            Error::UnsupportedDataStructureUnitStruct
+            Error::MissingReferencedKey("hammer".to_owned())
         );
     }
 
     #[test]
-    fn test_the_relations_method_fails_explicitly_on_invalid_type() {
+    fn test_the_fields_handles_implicit_referenced_key() {
         // Arrange the analysis
         let analysis = FactoryAnalysis::from(parse_quote! {
             struct Anvil {
-                #[factory(relation = 1)]
+                #[fabrique(relation = "Hammer")]
                 hammer_id: u32,
             }
         });
 
         // Act the call to the analyze method
-        let result = analysis.relations();
-
-        // Assert the result
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err(),
-            Error::UnparsableLiteral("1".to_owned())
-        );
-    }
-
-    #[test]
-    fn test_the_relations_method_handles_different_annotations() {
-        // Arrange the analysis
-        let analysis = FactoryAnalysis::from(parse_quote! {
-            struct Anvil {
-                #[factory(other = "foo")]
-                hammer_id: u32,
-
-                #[foo]
-                density: u32,
-
-                #[factory(unamed)]
-                weight: u32,
-            }
-        });
-
-        // Act the call to the analyze method
-        let result = analysis.relations();
+        let result = analysis.fields();
 
         // Assert the result
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().len(), 0);
+        let result = result.unwrap();
+        assert!(result.iter().any(|field| {
+            if field.field.ident.as_ref().unwrap() != "hammer_id" {
+                return false;
+            }
+
+            assert!(field.relation.is_some());
+            let relation = field.relation.as_ref().unwrap();
+            assert_eq!(relation.referenced_key.to_string(), "id");
+            assert_eq!(relation.name, "hammer");
+
+            true
+        }));
     }
 
     #[test]
-    fn test_the_relations_method_fails_explicitly_on_invalid_annotation() {
+    fn test_the_fields_handles_explicit_referenced_key() {
         // Arrange the analysis
         let analysis = FactoryAnalysis::from(parse_quote! {
             struct Anvil {
-                #[factory(relation = 1)]
-                hammer_id: u32,
+                #[fabrique(relation = "Hammer", referenced_key = "id")]
+                hammer: u32,
             }
         });
 
         // Act the call to the analyze method
-        let result = analysis.relations();
+        let result = analysis.fields();
 
         // Assert the result
-        assert!(result.is_err());
+        assert!(result.is_ok());
+        let result = result.unwrap();
+        assert!(result.iter().any(|field| {
+            if field.field.ident.as_ref().unwrap() != "hammer" {
+                return false;
+            }
+
+            assert!(field.relation.is_some());
+            let relation = field.relation.as_ref().unwrap();
+            assert_eq!(relation.referenced_key.to_string(), "id");
+            assert_eq!(relation.name, "hammer");
+
+            true
+        }));
+    }
+
+    #[test]
+    fn test_the_fields_method_handles_different_annotations() {
+        // Arrange the analysis
+        let analysis = FactoryAnalysis::from(parse_quote! {
+            struct Anvil {
+                #[foo]
+                density: u32,
+            }
+        });
+
+        // Act the call to the analyze method
+        let result = analysis.fields();
+
+        // Assert the result
+        assert!(result.is_ok());
         assert_eq!(
-            result.unwrap_err(),
-            Error::UnparsableLiteral("1".to_owned())
+            result
+                .unwrap()
+                .iter()
+                .filter(|field| field.relation.is_none())
+                .count(),
+            1
         );
     }
 
@@ -322,31 +556,36 @@ mod tests {
         // Arrange the relation
         let factory = FactoryAnalysis::from(parse_quote! {
             struct Anvil {
-                weight: u32,
+                hammer_id: u32,
             }
         });
         let field = &factory.fields().unwrap()[0];
 
         // Act the relation instantiation
-        let result = Relation::new(field, syn::parse_str("\"u32\"").unwrap());
+        let result = Relation::new(
+            &field.field,
+            FabriqueFieldAttributes {
+                relation: Some(Ident::new("Hammer", field.field.span())),
+                referenced_key: Some(Ident::new("id", field.field.span())),
+                ..Default::default()
+            },
+        );
 
         // Assert the result
         assert!(result.is_ok());
+        assert!(result.unwrap().is_some());
     }
 
     #[test]
-    fn test_a_relation_creation_fails_explicitly_on_invalid_ty() {
-        // Arrange the relation
-        let factory = FactoryAnalysis::from(parse_quote! {
-            struct Anvil {
-                weight: u32,
-            }
-        });
-        let field = &factory.fields().unwrap()[0];
+    fn test_field_attribute_parsing_fails_explicitly_on_invalid_referenced_type() {
+        // Arrange the field
+        let field = parse_quote! {
+            #[fabrique(relation = "Not A Valid Type")]
+            hammer_id: u32
+        };
 
-        // Act the relation instantiation
-        let literal = LitStr::new("Not A Valid Type", field.span());
-        let result = Relation::new(field, literal);
+        // Act the field parsing
+        let result = FabriqueFieldAttributes::from_field(&field);
 
         // Assert the result
         assert!(result.is_err());
@@ -364,8 +603,14 @@ mod tests {
         };
 
         // Act the relation instantiation
-        let literal = LitStr::new("Not A Valid Type", field.span());
-        let result = Relation::new(&field, literal);
+        let result = Relation::new(
+            &field,
+            FabriqueFieldAttributes {
+                relation: Some(Ident::new("Hammer", field.span())),
+                referenced_key: Some(Ident::new("id", field.span())),
+                ..Default::default()
+            },
+        );
 
         // Assert the result
         assert!(result.is_err());

--- a/fabrique-derive/src/codegen.rs
+++ b/fabrique-derive/src/codegen.rs
@@ -2,7 +2,10 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{DeriveInput, Ident};
 
-use crate::analysis::{FactoryAnalysis, FactoryAnalysisOutput};
+use crate::{
+    analysis::{FactoryAnalysis, FactoryAnalysisOutput},
+    error::Error,
+};
 
 /// Code generator for factory struct implementations.
 pub struct FactoryCodegen {
@@ -14,18 +17,18 @@ pub struct FactoryCodegen {
 
 impl FactoryCodegen {
     /// Creates a code generator from the given derive input.
-    pub fn from(input: DeriveInput) -> Self {
-        let output = FactoryAnalysis::from(input.clone()).analyze().unwrap();
-        Self {
+    pub fn from(input: DeriveInput) -> Result<Self, Error> {
+        let output = FactoryAnalysis::from(input.clone()).analyze()?;
+        Ok(Self {
             analysis: output,
             input,
-        }
+        })
     }
 
     /// Generates the complete factory implementation as a token stream.
     pub fn generate_factory(self) -> TokenStream {
         let base_struct_ident = &self.analysis.base_struct_ident;
-        let factory_ident = self.generate_factory_ident();
+        let factory_ident = Self::generate_factory_ident(&self.input.ident);
         let factory_fields = self.generate_factory_fields();
         let factory_method_create = self.generate_factory_method_create();
         let factory_method_new = self.generate_factory_method_new();
@@ -63,8 +66,8 @@ impl FactoryCodegen {
     /// or let the factory generate defaults when building the final struct.
     fn generate_factory_fields(&self) -> impl Iterator<Item = TokenStream> {
         self.analysis.fields.clone().into_iter().map(|field| {
-            let name = &field.ident;
-            let ty = &field.ty;
+            let name = &field.field.ident;
+            let ty = &field.field.ty;
             quote! {
                 #name: std::option::Option<#ty>
             }
@@ -73,9 +76,10 @@ impl FactoryCodegen {
 
     /// Generates factory relation fields for linked factory dependencies.
     fn generate_factory_relation_fields(&self) -> impl Iterator<Item = TokenStream> {
-        self.analysis.relations.iter().map(|relation| {
-            let ident = &relation.ident;
-            let ty = &relation.ty;
+        self.analysis.relations().map(|(_, relation)| {
+            let ident = &relation.factory_field;
+            let ty = Self::generate_factory_ident(&relation.referenced_type);
+
             quote! {
                 #ident: std::option::Option<Box<dyn FnOnce(#ty) -> #ty + Send>>
 
@@ -84,9 +88,9 @@ impl FactoryCodegen {
     }
 
     /// Generates the factory identifier with "Factory" suffix.
-    fn generate_factory_ident(&self) -> Ident {
-        let factory_name = format!("{}Factory", &self.input.ident);
-        Ident::new(&factory_name, self.input.ident.span())
+    fn generate_factory_ident(ident: &Ident) -> Ident {
+        let factory_name = format!("{}Factory", ident);
+        Ident::new(&factory_name, ident.span())
     }
 
     /// Generates the `create()` method for the factory struct.
@@ -98,15 +102,16 @@ impl FactoryCodegen {
     fn generate_factory_method_create(&self) -> TokenStream {
         // Generate relation creation code - related objects are created first
         // to establish the dependency graph before creating the main object
-        let relations_create = self.analysis.relations.iter().map(|relation| {
-            let field = &relation.field.ident;
-            let ident = &relation.ident;
-            let ty = &relation.ty;
+        let relations_create = self.analysis.relations().map(|(field, relation)| {
+            let field = &field.ident;
+            let ident = &relation.factory_field;
+            let ty = Self::generate_factory_ident(&relation.referenced_type);
+            let referenced_key = &relation.referenced_key;
 
             quote! {
                 if let Some(callback) = self.#ident {
                     let instance = callback(#ty::new()).create(connection).await?;
-                    self.#field = Some(instance.id);
+                    self.#field = Some(instance.#referenced_key);
                 }
             }
         });
@@ -114,8 +119,8 @@ impl FactoryCodegen {
         // Generate struct field initialization - use provided values or defaults
         let struct_ident = &self.analysis.base_struct_ident;
         let struct_fields = self.analysis.fields.iter().map(|field| {
-            let name = &field.ident;
-            let ty = &field.ty;
+            let name = &field.field.ident;
+            let ty = &field.field.ty;
 
             quote! {
                 #name: self.#name.unwrap_or(<#ty as Default>::default())
@@ -139,14 +144,14 @@ impl FactoryCodegen {
     /// Generates the `new()` method for the factory struct.
     fn generate_factory_method_new(&self) -> TokenStream {
         let initialized_fields = self.analysis.fields.clone().into_iter().map(|field| {
-            let name = &field.ident;
+            let name = &field.field.ident;
             quote! {
                 #name: None
             }
         });
 
-        let initialized_relation_fields = self.analysis.relations.iter().map(|relation| {
-            let name = &relation.ident;
+        let initialized_relation_fields = self.analysis.relations().map(|(_, relation)| {
+            let name = &relation.factory_field;
             quote! {
                 #name: None
             }
@@ -164,8 +169,8 @@ impl FactoryCodegen {
 
     fn generate_factory_method_fields(&self) -> impl Iterator<Item = TokenStream> {
         self.analysis.fields.clone().into_iter().map(|field| {
-            let name = &field.ident;
-            let ty = &field.ty;
+            let name = &field.field.ident;
+            let ty = &field.field.ty;
 
             quote! {
                 pub fn #name(mut self, #name: #ty) -> Self {
@@ -181,10 +186,10 @@ impl FactoryCodegen {
     /// These methods allow buffering the creation of related factory instances,
     /// which are then executed when building the final object.
     fn generate_factory_methods_for_relation(&self) -> impl Iterator<Item = TokenStream> {
-        self.analysis.relations.iter().map(|relation| {
-            let ty = &relation.ty;
-            let method_name = Ident::new(&format!("for_{}", &relation.name), relation.ident.span());
-            let field_ident = &relation.ident;
+        self.analysis.relations().map(|(_, relation)| {
+            let ty = Self::generate_factory_ident(&relation.referenced_type);
+            let method_name = Ident::new(&format!("for_{}", &relation.name), ty.span());
+            let field_ident = &relation.factory_field;
             quote! {
                 pub fn #method_name<F>(mut self, callback: F) -> Self
                 where F: FnOnce(#ty) -> #ty + Send + 'static
@@ -208,12 +213,13 @@ mod tests {
         // Arrange the codegen
         let codegen = FactoryCodegen::from(parse_quote! {
             struct Anvil {
-                #[factory(relation = "HammerFactory")]
+                #[fabrique(relation = "Hammer")]
                 hammer_id: u32,
                 hardness: u32,
                 weight: u32,
             }
-        });
+        })
+        .unwrap();
 
         // Act the call to the factory ident method
         let generated = codegen.generate_factory();
@@ -293,7 +299,8 @@ mod tests {
             struct Anvil {
                 weight: u32,
             }
-        });
+        })
+        .unwrap();
 
         // Act the call to the codegen fields method
         let generated: Vec<TokenStream> = codegen.generate_factory_fields().collect();
@@ -310,10 +317,11 @@ mod tests {
         // Arrange the codegen
         let codegen = FactoryCodegen::from(parse_quote! {
             struct Dynamite {
-                #[factory(relation = "ExplosiveFactory")]
+                #[fabrique(relation = "Explosive")]
                 explosive_id: String,
             }
-        });
+        })
+        .unwrap();
 
         // Act the call to the codegen fields method
         let generated: Vec<TokenStream> = codegen.generate_factory_relation_fields().collect();
@@ -332,10 +340,11 @@ mod tests {
         // Arrange the codegen
         let factory = FactoryCodegen::from(parse_quote! {
             struct Anvil {}
-        });
+        })
+        .unwrap();
 
         // Act the call to the factory ident method
-        let generated = factory.generate_factory_ident();
+        let generated = FactoryCodegen::generate_factory_ident(&factory.input.ident);
 
         // Assert the result
         assert_eq!(&generated, "AnvilFactory");
@@ -346,12 +355,13 @@ mod tests {
         // Arrange the codegen
         let factory = FactoryCodegen::from(parse_quote! {
             struct Anvil {
-                #[factory(relation = "HammerFactory")]
+                #[fabrique(relation = "Hammer")]
                 hammer_id: u32,
                 hardness: u32,
                 weight: u32,
             }
-        });
+        })
+        .unwrap();
 
         // Act the call to the factory ident method
         let generated = factory.generate_factory_method_create();
@@ -386,7 +396,8 @@ mod tests {
                 hardness: u32,
                 weight: u32,
             }
-        });
+        })
+        .unwrap();
 
         // Act the call to the factory ident method
         let generated = factory.generate_factory_method_new();
@@ -414,7 +425,8 @@ mod tests {
                 hardness: u32,
                 weight: u32,
             }
-        });
+        })
+        .unwrap();
 
         // Act the call to the generate_factory_method_fields method
         let generated: Vec<TokenStream> = factory.generate_factory_method_fields().collect();
@@ -437,10 +449,11 @@ mod tests {
         // Arrange the codegen
         let factory = FactoryCodegen::from(parse_quote! {
             struct Dynamite {
-                #[factory(relation = "ExplosiveFactory")]
+                #[fabrique(relation = "Explosive")]
                 explosive_id: String,
             }
-        });
+        })
+        .unwrap();
 
         // Act the call to the generate_factory_method_fields method
         let generated: Vec<TokenStream> = factory.generate_factory_methods_for_relation().collect();

--- a/fabrique-derive/src/error.rs
+++ b/fabrique-derive/src/error.rs
@@ -3,8 +3,12 @@
 pub enum Error {
     #[error("Expected a literal str, got {0:?}")]
     UnparsableLiteral(String),
+
     #[error("Could not parse literal to an ident: {0}")]
     UnparsableType(String),
+
+    #[error("Could not parse attribute: {0}")]
+    UnparsableAttribute(String),
 
     #[error("Factory can only be derived from named structs, enum given")]
     UnsupportedDataStructureEnum,
@@ -17,4 +21,12 @@ pub enum Error {
 
     #[error("Factory can only be derived from named structs, unit struct given")]
     UnsupportedDataStructureUnitStruct,
+
+    #[error("Unknown attribute: {0}")]
+    UnknownAttribute(String),
+
+    #[error(
+        "The relation {0} is missing a referenced key. By default, the suffix of the field is used (e.g. the referenced key of the relation `hammer_id` is `id`). Please use the `referenced_key` attribute or give this field a suffix."
+    )]
+    MissingReferencedKey(String),
 }

--- a/fabrique-derive/src/lib.rs
+++ b/fabrique-derive/src/lib.rs
@@ -6,7 +6,7 @@
 
 use crate::codegen::FactoryCodegen;
 use proc_macro::TokenStream;
-use syn::{DeriveInput, parse_macro_input};
+use syn::{DeriveInput, Error, parse_macro_input, spanned::Spanned};
 
 mod analysis;
 mod codegen;
@@ -34,10 +34,16 @@ mod error;
 /// Additionally generates:
 /// - `new() -> Self` - Creates a new factory instance with all fields set to `None`
 /// - `create(connection) -> Result<Struct, Error>` - Creates and persists the object if it implements `Persistable`
-#[proc_macro_derive(Factory, attributes(factory))]
+#[proc_macro_derive(Factory, attributes(factory, fabrique))]
 pub fn derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    FactoryCodegen::from(input).generate_factory().into()
+    let span = input.span();
+    match FactoryCodegen::from(input) {
+        Ok(codegen) => codegen,
+        Err(e) => return Error::new(span, e).into_compile_error().into(),
+    }
+    .generate_factory()
+    .into()
 }
 
 #[cfg(test)]

--- a/fabrique/tests/integration_test.rs
+++ b/fabrique/tests/integration_test.rs
@@ -1,10 +1,12 @@
 use fabrique::{Factory, Persistable};
 
+// Darling ?
 #[derive(Debug, Default, Eq, Factory, PartialEq)]
 struct Anvil {
+    #[fabrique(primary_key)]
     id: u32,
 
-    #[factory(relation = "HammerFactory")]
+    #[fabrique(relation = "Hammer")]
     hammer_id: u32,
     hardness: u32,
     weight: u32,
@@ -22,6 +24,7 @@ impl Persistable for Anvil {
 
 #[derive(Debug, Default, Eq, Factory, PartialEq)]
 struct Hammer {
+    #[fabrique(primary_key)]
     id: u32,
     weight: u32,
 }


### PR DESCRIPTION
# Goal
The goal of this PR is to be able to explicitly target a key in a referenced type, instead of relying on the presence of an `id` field.

This also comes with the introduction of the `primary_key` attribute, that could be used to infer the referenced key by default without a suffix later.

All the attributes have been moved in the `fabrique` namespace, as they will be common to the Factory and Repository macros.

# Syntax

```rust
#[derive(Debug, Default, Eq, Factory, PartialEq)]
struct Anvil {
    #[fabrique(primary_key)]
    id: u32,

    #[fabrique(relation = "Hammer", referenced_key = "id")]
    hammer_id: u32,
    hardness: u32,
    weight: u32,
}

impl Persistable for Anvil {
    type Connection = ();

    type Error = ();

    async fn create(self, _connection: &Self::Connection) -> Result<Self, Self::Error> {
        Ok(self)
    }
}

#[derive(Debug, Default, Eq, Factory, PartialEq)]
struct Hammer {
    #[fabrique(primary_key)]
    id: u32,
    weight: u32,
}
```

If a relation is defined with no explicit `referenced_key` attribute, it is infered with the suffix of the field. If there is no suffix, an error is thrown.