### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/robinstraub/fabrique/compare/fabrique-v0.2.0...fabrique-v0.2.1) - 2026-02-09
+
+### Added
+
+- add named join support ([#113](https://github.com/robinstraub/fabrique/pull/113))
+- auto-create belongs-to relations with factories ([#111](https://github.com/robinstraub/fabrique/pull/111))
+- add insert entrypoint to model ([#110](https://github.com/robinstraub/fabrique/pull/110))
+- add type-safe column selection support ([#89](https://github.com/robinstraub/fabrique/pull/89))
+- add support for multiple backends ([#79](https://github.com/robinstraub/fabrique/pull/79))
+
+### Other
+
+- centralize changelog ([#116](https://github.com/robinstraub/fabrique/pull/116))
+- allow Into types to be passed to reduce noise ([#109](https://github.com/robinstraub/fabrique/pull/109))
+- clarify fabrique positionning ([#108](https://github.com/robinstraub/fabrique/pull/108))
+- make select implicit on base model ([#90](https://github.com/robinstraub/fabrique/pull/90))
+- add markdown codestyle check ([#83](https://github.com/robinstraub/fabrique/pull/83))
+
 ## [0.2.0](https://github.com/robinstraub/fabrique/compare/fabrique-v0.1.1...fabrique-v0.2.0) - 2026-01-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "fabrique"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "cargo-husky",
  "chrono",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "fabrique-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "fabrique",
  "fabrique-derive",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "fabrique-derive"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "darling",
  "fabrique",

--- a/fabrique-core/Cargo.toml
+++ b/fabrique-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fabrique-core"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "Core traits and types for Fabrique"
 license = "MIT"

--- a/fabrique-derive/Cargo.toml
+++ b/fabrique-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fabrique-derive"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "Derive macros for Fabrique"
 license = "MIT"
@@ -18,7 +18,7 @@ proc-macro = true
 
 [dependencies]
 darling = "0.21"
-fabrique-core = { path = "../fabrique-core", version = "0.2.0" }
+fabrique-core = { path = "../fabrique-core", version = "0.2.1" }
 heck = "0.5"
 pluralizer = "0.4"
 proc-macro2 = "1.0"

--- a/fabrique/Cargo.toml
+++ b/fabrique/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fabrique"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "SQL-first, type-safe, ergonomic database toolkit for Rust"
 license = "MIT"
@@ -19,8 +19,8 @@ mysql = ["fabrique-core/mysql", "fabrique-derive/mysql"]
 sqlite = ["fabrique-core/sqlite", "fabrique-derive/sqlite"]
 
 [dependencies]
-fabrique-core = { path = "../fabrique-core", version = "0.2.0" }
-fabrique-derive = { path = "../fabrique-derive", version = "0.2.0" }
+fabrique-core = { path = "../fabrique-core", version = "0.2.1" }
+fabrique-derive = { path = "../fabrique-derive", version = "0.2.1" }
 fake = { workspace = true, optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION



## 🤖 New release

* `fabrique-core`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `fabrique-derive`: 0.2.0 -> 0.2.1
* `fabrique`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



## `fabrique`

<blockquote>

## [0.2.1](https://github.com/robinstraub/fabrique/compare/fabrique-v0.2.0...fabrique-v0.2.1) - 2026-02-09

### Added

- add named join support ([#113](https://github.com/robinstraub/fabrique/pull/113))
- auto-create belongs-to relations with factories ([#111](https://github.com/robinstraub/fabrique/pull/111))
- add insert entrypoint to model ([#110](https://github.com/robinstraub/fabrique/pull/110))
- add type-safe column selection support ([#89](https://github.com/robinstraub/fabrique/pull/89))
- add support for multiple backends ([#79](https://github.com/robinstraub/fabrique/pull/79))

### Other

- centralize changelog ([#116](https://github.com/robinstraub/fabrique/pull/116))
- allow Into types to be passed to reduce noise ([#109](https://github.com/robinstraub/fabrique/pull/109))
- clarify fabrique positionning ([#108](https://github.com/robinstraub/fabrique/pull/108))
- make select implicit on base model ([#90](https://github.com/robinstraub/fabrique/pull/90))
- add markdown codestyle check ([#83](https://github.com/robinstraub/fabrique/pull/83))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).