### PR TITLE
feat: auto-create belongs-to relations with factories

### DIFF
--- a/docs/src/concepts/factories.md
+++ b/docs/src/concepts/factories.md
@@ -83,9 +83,9 @@ list of available generators.
 
 ## Relation Support
 
-Factories understand model relationships. `for_<relation>()`
-accepts either a **factory** (to create a new parent) or a
-**model instance** (to reuse an existing one):
+Factories understand `belongs_to` relationships. When a
+factory creates a record with a foreign key, it automatically
+creates the parent record if none is specified:
 
 ```rust
 # extern crate fabrique;
@@ -113,7 +113,54 @@ accepts either a **factory** (to create a new parent) or a
 #
 # #[fabrique::doctest]
 # async fn main(pool: Pool<Backend>) -> Result<(), fabrique::Error> {
-// Pass a factory: creates a new user for this order
+// A User is auto-created — no manual setup needed
+let order = Order::factory()
+    .create(&pool)
+    .await?;
+
+assert_ne!(order.user_id, Uuid::nil());
+# Ok(())
+# }
+```
+
+> **Cyclic relation graphs:** If your relation graph contains
+> a cycle, you might wonder whether auto-creation recurses
+> infinitely. It doesn't — SQL already requires at least one
+> foreign key in the cycle to be nullable, and factories skip
+> optional foreign keys (`Option<Uuid>`), which breaks the
+> chain.
+
+Use `for_<relation>()` to take control — pass a **factory**
+to customize the parent, or a **model instance** to reuse an
+existing one:
+
+```rust
+# extern crate fabrique;
+# extern crate sqlx;
+# extern crate tokio;
+# extern crate uuid;
+# use fabrique::prelude::*;
+# use uuid::Uuid;
+#
+# #[derive(Clone, Model, Factory)]
+# pub struct User {
+#     pub id: Uuid,
+#     pub name: String,
+#     pub email: String,
+#     pub orders: HasMany<Order>,
+# }
+#
+# #[derive(Clone, Model, Factory)]
+# pub struct Order {
+#     pub id: Uuid,
+#     pub status: String,
+#     #[fabrique(belongs_to = "User")]
+#     pub user_id: Uuid,
+# }
+#
+# #[fabrique::doctest]
+# async fn main(pool: Pool<Backend>) -> Result<(), fabrique::Error> {
+// Pass a factory: creates a new user with specific attributes
 let order = Order::factory()
     .for_user(User::factory().name("Wile E.".to_string()))
     .create(&pool)
@@ -220,9 +267,8 @@ assert_eq!(orders.len(), 3);
 # }
 ```
 
-Both combine for complex object graphs in a single call. Since
-`for_<relation>()` accepts a factory, you can nest them to chain
-dependencies:
+Both combine for complex object graphs in a single call.
+Missing parents are auto-created at every level of the chain:
 
 ```rust
 # extern crate fabrique;
@@ -273,20 +319,16 @@ dependencies:
 # async fn main(pool: Pool<Backend>) -> Result<(), fabrique::Error> {
 // 1 order, 3 order lines, each with its own product
 let order = Order::factory()
-    .for_user(User::factory())
-    .has_order_lines(
-        OrderLine::factory()
-            .for_product(Product::factory()),
-        3,
-    )
+    .has_order_lines(OrderLine::factory(), 3)
     .create(&pool)
     .await?;
 # Ok(())
 # }
 ```
 
-The factory creates records in dependency order: products first,
-then order lines with the correct foreign keys, then the order.
+The factory creates records in dependency order: a user and
+products are auto-created, then order lines with the correct
+foreign keys, then the order — all from a single chain.
 
 ---
 

--- a/docs/src/concepts/query-builder.md
+++ b/docs/src/concepts/query-builder.md
@@ -316,8 +316,7 @@ no relationship is declared between the models, it won't compile:
 #
 # #[fabrique::doctest]
 # async fn main(pool: Pool<Backend>) -> Result<(), fabrique::Error> {
-# let user = User::factory().create(&pool).await?;
-# Order::factory().for_user(user).create(&pool).await?;
+# Order::factory().create(&pool).await?;
 // Both directions work — the relation is declared once
 let users = User::query()
     .join::<Order>()
@@ -381,7 +380,7 @@ chain must be valid at each step:
 #
 # #[fabrique::doctest]
 # async fn main(pool: Pool<Backend>) -> Result<(), fabrique::Error> {
-# Order::factory().for_user(User::factory()).create(&pool).await?;
+# Order::factory().create(&pool).await?;
 // Order → OrderLine (direct) → Product (through OrderLine)
 let orders = Order::query()
     .join::<OrderLine>()
@@ -486,8 +485,7 @@ model:
 #
 # #[fabrique::doctest]
 # async fn main(pool: Pool<Backend>) -> Result<(), fabrique::Error> {
-# let user = User::factory().create(&pool).await?;
-# Order::factory().for_user(user).create(&pool).await?;
+# Order::factory().create(&pool).await?;
 let orders: Vec<Order> = User::query()
     .join::<Order>()
     .select_as::<Order, _>()
@@ -555,8 +553,7 @@ present:
 #
 # #[fabrique::doctest]
 # async fn main(pool: Pool<Backend>) -> Result<(), fabrique::Error> {
-# let user = User::factory().create(&pool).await?;
-# Order::factory().for_user(user).create(&pool).await?;
+# Order::factory().create(&pool).await?;
 let rows: Vec<(String, String)> = User::query()
     .join::<Order>()
     .select((User::NAME, Order::STATUS))

--- a/docs/src/cookbook/simplify-test-setup-with-factories.md
+++ b/docs/src/cookbook/simplify-test-setup-with-factories.md
@@ -14,8 +14,8 @@ For the full factory API, see
 ## Seed a Full Order in One Chain
 
 An order needs a user, products, and the join records linking
-them. With factories, the entire graph is built from the
-leaf up:
+them. With factories, the entire graph is built in one chain
+— missing parents are auto-created:
 
 ```rust
 # extern crate fabrique;
@@ -62,7 +62,6 @@ leaf up:
 # #[fabrique::doctest]
 # async fn main(pool: Pool<Backend>) -> Result<(), fabrique::Error> {
 let order = Order::factory()
-    .for_user(User::factory())
     .has_products(Product::factory(), 3)
     .create(&pool)
     .await?;
@@ -162,13 +161,11 @@ generate everything else:
 # async fn main(pool: Pool<Backend>) -> Result<(), fabrique::Error> {
 // Arrange — only the status matters for this test
 Order::factory()
-    .for_user(User::factory())
     .status("shipped".to_string())
     .create(&pool)
     .await?;
 
 Order::factory()
-    .for_user(User::factory())
     .status("pending".to_string())
     .create(&pool)
     .await?;

--- a/fabrique-derive/src/codegen/factory.rs
+++ b/fabrique-derive/src/codegen/factory.rs
@@ -265,15 +265,26 @@ impl<'a> FactoryCodegen<'a> {
             let field = &relation.base_ident;
             let factory_field = relation.factory_field;
             let enum_ident = Self::relation_enum_ident(&struct_name, relation.name);
+            let factory_type = Ident::new(
+                &format!("{}Factory", relation.referenced_type),
+                relation.referenced_type.span(),
+            );
 
             quote! {
-                if let Some(relation) = self.#factory_field.take() {
-                    let key = match relation {
-                        #enum_ident::PrimaryKey(pk) => pk,
-                        #enum_ident::Factory(factory) => {
+                {
+                    let key = match self.#factory_field.take() {
+                        Some(#enum_ident::PrimaryKey(pk)) => pk,
+                        Some(#enum_ident::Factory(factory)) => {
                             let instance = fabrique::Factory::create(factory, &mut *conn).await?;
                             fabrique::Model::primary_key(&instance)
                         }
+                        None => match self.#field.take() {
+                            Some(pk) => pk,
+                            None => {
+                                let instance = fabrique::Factory::create(#factory_type::new(), &mut *conn).await?;
+                                fabrique::Model::primary_key(&instance)
+                            }
+                        },
                     };
                     self.#field = Some(key);
                 }
@@ -606,13 +617,20 @@ mod tests {
                             let mut conn = executor.acquire().await
                                 .map_err(|e| <Anvil as fabrique::DatabaseAware>::Error::from(e))?;
 
-                            if let Some(relation) = self.hammer_relation.take() {
-                                let key = match relation {
-                                    AnvilHammerRelation::PrimaryKey(pk) => pk,
-                                    AnvilHammerRelation::Factory(factory) => {
+                            {
+                                let key = match self.hammer_relation.take() {
+                                    Some(AnvilHammerRelation::PrimaryKey(pk)) => pk,
+                                    Some(AnvilHammerRelation::Factory(factory)) => {
                                         let instance = fabrique::Factory::create(factory, &mut *conn).await?;
                                         fabrique::Model::primary_key(&instance)
                                     }
+                                    None => match self.hammer_id.take() {
+                                        Some(pk) => pk,
+                                        None => {
+                                            let instance = fabrique::Factory::create(HammerFactory::new(), &mut *conn).await?;
+                                            fabrique::Model::primary_key(&instance)
+                                        }
+                                    },
                                 };
                                 self.hammer_id = Some(key);
                             }
@@ -764,13 +782,20 @@ mod tests {
                         let mut conn = executor.acquire().await
                             .map_err(|e| <Anvil as fabrique::DatabaseAware>::Error::from(e))?;
 
-                        if let Some(relation) = self.hammer_relation.take() {
-                            let key = match relation {
-                                AnvilHammerRelation::PrimaryKey(pk) => pk,
-                                AnvilHammerRelation::Factory(factory) => {
+                        {
+                            let key = match self.hammer_relation.take() {
+                                Some(AnvilHammerRelation::PrimaryKey(pk)) => pk,
+                                Some(AnvilHammerRelation::Factory(factory)) => {
                                     let instance = fabrique::Factory::create(factory, &mut *conn).await?;
                                     fabrique::Model::primary_key(&instance)
                                 }
+                                None => match self.hammer_id.take() {
+                                    Some(pk) => pk,
+                                    None => {
+                                        let instance = fabrique::Factory::create(HammerFactory::new(), &mut *conn).await?;
+                                        fabrique::Model::primary_key(&instance)
+                                    }
+                                },
                             };
                             self.hammer_id = Some(key);
                         }

--- a/fabrique/tests/factory.rs
+++ b/fabrique/tests/factory.rs
@@ -53,6 +53,16 @@ pub struct OrderLine {
 }
 
 #[fabrique_derive::test]
+async fn test_auto_creates_belongs_to(connection: Pool<Backend>) {
+    // Order has belongs_to User — create without for_user()
+    let order = Order::factory().create(&connection).await.unwrap();
+
+    // A User was auto-created and the FK is valid
+    let user = User::find(&connection, order.user_id).await.unwrap();
+    assert_eq!(user.id, order.user_id);
+}
+
+#[fabrique_derive::test]
 async fn test_factory_for_relations_accept_models(connection: Pool<Backend>) {
     let user = User::factory().create(&connection).await.unwrap();
     let product = Product::factory().create(&connection).await.unwrap();
@@ -73,7 +83,7 @@ async fn test_factory_for_relations_accept_models(connection: Pool<Backend>) {
 #[fabrique_derive::test]
 async fn test_factory_for_relations_accept_factories(connection: Pool<Backend>) {
     OrderLine::factory()
-        .for_order(Order::factory().for_user(User::factory()))
+        .for_order(Order::factory())
         .for_product(Product::factory())
         .create(&connection)
         .await
@@ -105,7 +115,6 @@ async fn test_has_many_creates_children(connection: Pool<Backend>) {
 async fn test_many_to_many_through_creates_join_records(connection: Pool<Backend>) {
     // Create an Order with 1 Product through OrderLine (many-to-many)
     let order = Order::factory()
-        .for_user(User::factory())
         .has_products(Product::factory().name("Anvil 3000".to_string()), 1)
         .create(&connection)
         .await


### PR DESCRIPTION
resolves #106 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Factories now automatically create required parent records in `belongs_to` relationships, enabling complete object graphs to be built in a single chain without manual parent setup.

* **Documentation**
  * Updated factory documentation and examples to reflect automatic parent creation and simplified workflow.
  * Added guidance for controlling relationships and handling cyclic dependency chains.

* **Tests**
  * Added test coverage for automatic parent record creation in factory chains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->