### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/robinstraub/fabrique/compare/fabrique-v0.2.1...fabrique-v0.2.2) - 2026-02-10
+
+### Fixed
+
+- expose rust type instead of the database type ([#123](https://github.com/robinstraub/fabrique/pull/123))
+
+### Other
+
+- tag sqlite feature for publishing docs ([#121](https://github.com/robinstraub/fabrique/pull/121))
+
 ## [0.2.1](https://github.com/robinstraub/fabrique/compare/fabrique-v0.2.0...fabrique-v0.2.1) - 2026-02-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "fabrique"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "cargo-husky",
  "chrono",
@@ -445,7 +445,7 @@ dependencies = [
 
 [[package]]
 name = "fabrique-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "fabrique",
  "fabrique-derive",
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "fabrique-derive"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "darling 0.21.3",
  "fabrique",

--- a/fabrique-core/Cargo.toml
+++ b/fabrique-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fabrique-core"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 description = "Core traits and types for Fabrique"
 license = "MIT"

--- a/fabrique-derive/Cargo.toml
+++ b/fabrique-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fabrique-derive"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 description = "Derive macros for Fabrique"
 license = "MIT"
@@ -21,7 +21,7 @@ proc-macro = true
 
 [dependencies]
 darling = "0.21"
-fabrique-core = { path = "../fabrique-core", version = "0.2.1" }
+fabrique-core = { path = "../fabrique-core", version = "0.2.2" }
 heck = "0.5"
 pluralizer = "0.4"
 proc-macro2 = "1.0"

--- a/fabrique/Cargo.toml
+++ b/fabrique/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fabrique"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 description = "SQL-first, type-safe, ergonomic database toolkit for Rust"
 license = "MIT"
@@ -20,8 +20,8 @@ sqlite = ["fabrique-core/sqlite", "fabrique-derive/sqlite"]
 doctests = ["fabrique-core/doctests"]
 
 [dependencies]
-fabrique-core = { path = "../fabrique-core", version = "0.2.1" }
-fabrique-derive = { path = "../fabrique-derive", version = "0.2.1" }
+fabrique-core = { path = "../fabrique-core", version = "0.2.2" }
+fabrique-derive = { path = "../fabrique-derive", version = "0.2.2" }
 fake = { workspace = true, optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION



## 🤖 New release

* `fabrique-core`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `fabrique-derive`: 0.2.1 -> 0.2.2
* `fabrique`: 0.2.1 -> 0.2.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



## `fabrique`

<blockquote>

## [0.2.2](https://github.com/robinstraub/fabrique/compare/fabrique-v0.2.1...fabrique-v0.2.2) - 2026-02-10

### Fixed

- expose rust type instead of the database type ([#123](https://github.com/robinstraub/fabrique/pull/123))

### Other

- tag sqlite feature for publishing docs ([#121](https://github.com/robinstraub/fabrique/pull/121))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.2.2 as a maintenance update with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->