### PR TITLE
feat: add upsert method

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,10 +149,10 @@ jobs:
           tool: mdbook,mdbook-mermaid
 
       - name: Build dependencies for doctests
-        run: cargo build --features sqlite,testing
+        run: cargo +1.93.0 build --features sqlite,testing
 
       - name: Build mdBook
         run: mdbook build docs
 
       - name: Test mdBook code examples
-        run: CARGO_MANIFEST_DIR=$PWD/docs mdbook test docs -L target/debug/deps
+        run: CARGO_MANIFEST_DIR=$PWD/docs rustup run 1.93.0 mdbook test docs -L target/debug/deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,10 @@ jobs:
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          # Pin to 1.93 to work around rustdoc E0464 with proc-macro
+          # duplicate rlibs in target/debug/deps (broken since 1.95+)
+          toolchain: 1.93.0
 
       - name: Install mdBook and preprocessors
         uses: taiki-e/install-action@v2

--- a/docs/src/concepts/factories.md
+++ b/docs/src/concepts/factories.md
@@ -43,6 +43,36 @@ assert_eq!(product.name, "Anvil 3000");
 
 Fields you don't set are filled with generated values automatically.
 
+## Building Without Persisting
+
+Use `make()` instead of `create()` to build a model instance
+in memory without hitting the database:
+
+```rust
+# extern crate fabrique;
+# extern crate sqlx;
+# extern crate uuid;
+# use fabrique::prelude::*;
+# use uuid::Uuid;
+#
+# #[derive(Model, Factory)]
+# pub struct Product {
+#     id: Uuid,
+#     name: String,
+#     price_cents: i32,
+# }
+# fn main() {
+let product: Product = Product::factory::<sqlx::Sqlite>()
+    .name("Anvil 3000".to_string())
+    .make();
+
+assert_eq!(product.name, "Anvil 3000");
+# }
+```
+
+This is useful for preparing data for bulk operations like
+[`upsert()`](../cookbook/bulk-update-and-upsert.md#bulk-upsert-a-collection).
+
 ## Random Value Generation
 
 By default, factories generate random values for all fields using

--- a/docs/src/concepts/models.md
+++ b/docs/src/concepts/models.md
@@ -255,8 +255,12 @@ let anvil: Product = Product::find(&pool, anvil.id).await?;
 // Upsert (insert or update on PK conflict)
 let anvil: Product = anvil.save(&pool).await?;
 
+// Bulk upsert a collection
+let products = vec![anvil];
+products.upsert(&pool, Product::ID).await?;
+
 // Delete by primary key, no instance needed
-Product::destroy(&pool, anvil.id).await?;
+Product::destroy(&pool, Uuid::new_v4()).await?;
 # Ok(())
 # }
 ```

--- a/docs/src/cookbook/bulk-update-and-upsert.md
+++ b/docs/src/cookbook/bulk-update-and-upsert.md
@@ -214,8 +214,8 @@ them all in a single statement:
 # #[fabrique::doctest]
 # async fn main(pool: Pool<Sqlite>) -> Result<(), fabrique::Error> {
 # let products = vec![
-#     Product::factory().name("Anvil 3000".to_string()).make(),
-#     Product::factory().name("Rocket Skates".to_string()).make(),
+#     Product::factory::<Sqlite>().name("Anvil 3000".to_string()).make(),
+#     Product::factory::<Sqlite>().name("Rocket Skates".to_string()).make(),
 # ];
 // Insert all products, or update on ID conflict
 products.upsert(&pool, Product::ID).await?;

--- a/docs/src/cookbook/bulk-update-and-upsert.md
+++ b/docs/src/cookbook/bulk-update-and-upsert.md
@@ -189,6 +189,73 @@ let saved: Product = Product::insert()
 values from the INSERT — the SQL equivalent of
 `SET col = EXCLUDED.col` for each column.
 
+## Bulk Upsert a Collection
+
+When you have a `Vec` of models to upsert — e.g. syncing an
+external data source — use `.upsert()` to insert or update
+them all in a single statement:
+
+```rust
+# extern crate fabrique;
+# extern crate sqlx;
+# extern crate tokio;
+# extern crate uuid;
+# use fabrique::prelude::*;
+# use uuid::Uuid;
+#
+# #[derive(Clone, Debug, Factory, Model)]
+# pub struct Product {
+#     pub id: Uuid,
+#     pub name: String,
+#     pub price_cents: i32,
+#     pub in_stock: bool,
+# }
+#
+# #[fabrique::doctest]
+# async fn main(pool: Pool<Sqlite>) -> Result<(), fabrique::Error> {
+# let products = vec![
+#     Product::factory().name("Anvil 3000".to_string()).make(),
+#     Product::factory().name("Rocket Skates".to_string()).make(),
+# ];
+// Insert all products, or update on ID conflict
+products.upsert(&pool, Product::ID).await?;
+# Ok(())
+# }
+```
+
+The second argument specifies the conflict target — the column
+(or columns) that identify a unique row. All other columns are
+updated when a conflict is detected.
+
+For a composite unique key, pass a tuple:
+
+```rust,no_run
+# extern crate fabrique;
+# extern crate sqlx;
+# extern crate uuid;
+# use fabrique::prelude::*;
+# use uuid::Uuid;
+# #[derive(Clone, Debug, Factory, Model)]
+# pub struct Product {
+#     pub id: Uuid,
+#     pub name: String,
+#     pub price_cents: i32,
+#     pub in_stock: bool,
+# }
+# async fn example(
+#     products: Vec<Product>,
+#     pool: Pool<Sqlite>,
+# ) -> Result<(), fabrique::Error> {
+products
+    .upsert(&pool, (Product::NAME, Product::PRICE_CENTS))
+    .await?;
+# Ok(())
+# }
+```
+
+> **Note:** The conflict target columns must have a UNIQUE
+> constraint or be the primary key in your database schema.
+
 If you only want to skip duplicates without updating, use
 `.do_nothing()`:
 

--- a/fabrique-core/src/lib.rs
+++ b/fabrique-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod factory;
 pub mod model;
 pub mod relation;
 pub mod sql;
+pub mod upsert;
 
 // Re-export for use in generated code
 pub use database::Nil;
@@ -24,3 +25,5 @@ pub use factory::SetForeignKey;
 pub use relation::Alias;
 pub use relation::BelongsTo;
 pub use relation::Joinable;
+pub use upsert::UniqueBy;
+pub use upsert::Upsert;

--- a/fabrique-core/src/model.rs
+++ b/fabrique-core/src/model.rs
@@ -116,6 +116,10 @@ pub trait Persist<DB: Dialect>: Model {
     ) -> impl Future<Output = Result<Self, crate::Error>> + Send + 'e
     where
         A: sqlx::Acquire<'e, Database = DB> + Send + 'e;
+
+    /// Pushes all field values as bind parameters into a separated
+    /// query builder row.
+    fn push_bind_values(self, separated: sqlx::query_builder::Separated<'_, DB, &'static str>);
 }
 
 /// Delete operations

--- a/fabrique-core/src/upsert.rs
+++ b/fabrique-core/src/upsert.rs
@@ -20,6 +20,7 @@ macro_rules! impl_unique_by {
         }
     };
 }
+impl_unique_by!(C0);
 impl_unique_by!(C0, C1);
 impl_unique_by!(C0, C1, C2);
 impl_unique_by!(C0, C1, C2, C3);
@@ -35,56 +36,6 @@ pub trait Upsert<DB: Dialect> {
     where
         A: sqlx::Acquire<'e, Database = DB> + Send + 'e,
         U: UniqueBy<Self::Model>;
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    struct MockModel;
-    struct ColA;
-    struct ColB;
-    struct ColC;
-
-    impl Column<MockModel> for ColA {
-        type Type = i32;
-        type DbType = i32;
-        const NAME: &'static str = "a";
-        const QUALIFIED_NAME: &'static str = "mocks.a";
-        fn into_db(value: i32) -> i32 {
-            value
-        }
-    }
-    impl Column<MockModel> for ColB {
-        type Type = i32;
-        type DbType = i32;
-        const NAME: &'static str = "b";
-        const QUALIFIED_NAME: &'static str = "mocks.b";
-        fn into_db(value: i32) -> i32 {
-            value
-        }
-    }
-    impl Column<MockModel> for ColC {
-        type Type = i32;
-        type DbType = i32;
-        const NAME: &'static str = "c";
-        const QUALIFIED_NAME: &'static str = "mocks.c";
-        fn into_db(value: i32) -> i32 {
-            value
-        }
-    }
-
-    #[test]
-    fn test_unique_by_tuple_2() {
-        let names = <(ColA, ColB)>::column_names();
-        assert_eq!(names, &["a", "b"]);
-    }
-
-    #[test]
-    fn test_unique_by_tuple_3() {
-        let names = <(ColA, ColB, ColC)>::column_names();
-        assert_eq!(names, &["a", "b", "c"]);
-    }
 }
 
 impl<M, DB> Upsert<DB> for Vec<M>

--- a/fabrique-core/src/upsert.rs
+++ b/fabrique-core/src/upsert.rs
@@ -1,0 +1,83 @@
+use crate::{
+    database::Column,
+    dialect::Dialect,
+    model::{Model, Persist},
+};
+
+pub trait UniqueBy<M> {
+    fn column_names() -> &'static [&'static str];
+}
+
+macro_rules! impl_unique_by {
+    ($($C:ident),+) => {
+        impl<M, $($C),+> UniqueBy<M> for ($($C,)+)
+        where
+            $($C: Column<M>,)+
+        {
+            fn column_names() -> &'static [&'static str] {
+                &[$($C::NAME),+]
+            }
+        }
+    };
+}
+impl_unique_by!(C0, C1);
+impl_unique_by!(C0, C1, C2);
+impl_unique_by!(C0, C1, C2, C3);
+
+pub trait Upsert<DB: Dialect> {
+    type Model: Model;
+
+    fn upsert<'e, A, U>(
+        self,
+        executor: A,
+        unique_by: U,
+    ) -> impl Future<Output = Result<(), crate::Error>>
+    where
+        A: sqlx::Acquire<'e, Database = DB> + Send + 'e,
+        U: UniqueBy<Self::Model>;
+}
+
+impl<M, DB> Upsert<DB> for Vec<M>
+where
+    M: Persist<DB> + Send,
+    DB: Dialect,
+    <DB as sqlx::Database>::Arguments: sqlx::IntoArguments<DB>,
+    for<'c> &'c mut <DB as sqlx::Database>::Connection: sqlx::Executor<'c, Database = DB>,
+{
+    type Model = M;
+
+    async fn upsert<'e, A, U>(self, executor: A, _unique_by: U) -> Result<(), crate::Error>
+    where
+        A: sqlx::Acquire<'e, Database = DB> + Send + 'e,
+        U: UniqueBy<M>,
+    {
+        if self.is_empty() {
+            return Ok(());
+        }
+
+        let mut conn = executor.acquire().await.map_err(crate::Error::from)?;
+
+        let mut qb = sqlx::QueryBuilder::new("INSERT INTO ");
+        qb.push(M::table_name());
+        qb.push(" (");
+        qb.push(M::columns().join(", "));
+        qb.push(") ");
+
+        qb.push_values(self, |separated, model| {
+            model.push_bind_values(separated);
+        });
+
+        let unique_cols = U::column_names();
+        qb.push(DB::on_conflict_sql(unique_cols));
+
+        let update_cols: Vec<&str> = M::columns()
+            .iter()
+            .copied()
+            .filter(|c| !unique_cols.contains(c))
+            .collect();
+        qb.push(DB::do_update_sql(&update_cols));
+
+        qb.build().execute(&mut *conn).await?;
+        Ok(())
+    }
+}

--- a/fabrique-core/src/upsert.rs
+++ b/fabrique-core/src/upsert.rs
@@ -37,6 +37,56 @@ pub trait Upsert<DB: Dialect> {
         U: UniqueBy<Self::Model>;
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MockModel;
+    struct ColA;
+    struct ColB;
+    struct ColC;
+
+    impl Column<MockModel> for ColA {
+        type Type = i32;
+        type DbType = i32;
+        const NAME: &'static str = "a";
+        const QUALIFIED_NAME: &'static str = "mocks.a";
+        fn into_db(value: i32) -> i32 {
+            value
+        }
+    }
+    impl Column<MockModel> for ColB {
+        type Type = i32;
+        type DbType = i32;
+        const NAME: &'static str = "b";
+        const QUALIFIED_NAME: &'static str = "mocks.b";
+        fn into_db(value: i32) -> i32 {
+            value
+        }
+    }
+    impl Column<MockModel> for ColC {
+        type Type = i32;
+        type DbType = i32;
+        const NAME: &'static str = "c";
+        const QUALIFIED_NAME: &'static str = "mocks.c";
+        fn into_db(value: i32) -> i32 {
+            value
+        }
+    }
+
+    #[test]
+    fn test_unique_by_tuple_2() {
+        let names = <(ColA, ColB)>::column_names();
+        assert_eq!(names, &["a", "b"]);
+    }
+
+    #[test]
+    fn test_unique_by_tuple_3() {
+        let names = <(ColA, ColB, ColC)>::column_names();
+        assert_eq!(names, &["a", "b", "c"]);
+    }
+}
+
 impl<M, DB> Upsert<DB> for Vec<M>
 where
     M: Persist<DB> + Send,

--- a/fabrique-derive/src/codegen/columns.rs
+++ b/fabrique-derive/src/codegen/columns.rs
@@ -70,6 +70,12 @@ impl<'a> ColumnsCodegen<'a> {
                         #into_db_body
                     }
                 }
+
+                impl ::fabrique::UniqueBy<#base_struct_ident> for #type_name {
+                    fn column_names() -> &'static [&'static str] {
+                        &[#column_name]
+                    }
+                }
             }
         });
 
@@ -127,6 +133,13 @@ mod tests {
                         value
                     }
                 }
+
+                impl ::fabrique::UniqueBy<Anvil> for AnvilIdColumn {
+                    fn column_names() -> &'static [&'static str] {
+                        &["id"]
+                    }
+                }
+
                 impl ::fabrique::Column<Anvil> for AnvilNameColumn {
                     type Type = String;
                     type DbType = String;
@@ -136,6 +149,12 @@ mod tests {
 
                     fn into_db(value: Self::Type) -> Self::DbType {
                         value
+                    }
+                }
+
+                impl ::fabrique::UniqueBy<Anvil> for AnvilNameColumn {
+                    fn column_names() -> &'static [&'static str] {
+                        &["name"]
                     }
                 }
 
@@ -182,6 +201,13 @@ mod tests {
                         value
                     }
                 }
+
+                impl ::fabrique::UniqueBy<Account> for AccountIdColumn {
+                    fn column_names() -> &'static [&'static str] {
+                        &["id"]
+                    }
+                }
+
                 impl ::fabrique::Column<Account> for AccountStatusColumn {
                     type Type = Status;
                     type DbType = String;
@@ -191,6 +217,12 @@ mod tests {
 
                     fn into_db(value: Self::Type) -> Self::DbType {
                         value.into()
+                    }
+                }
+
+                impl ::fabrique::UniqueBy<Account> for AccountStatusColumn {
+                    fn column_names() -> &'static [&'static str] {
+                        &["status"]
                     }
                 }
 

--- a/fabrique-derive/src/codegen/factory.rs
+++ b/fabrique-derive/src/codegen/factory.rs
@@ -1114,4 +1114,38 @@ mod tests {
             generated
         );
     }
+
+    #[test]
+    fn test_generate_factory_method_make_with_custom_faker() {
+        // Arrange
+        let input = parse_quote! {
+            struct User {
+                id: u32,
+                #[fabrique(faker = "Name()")]
+                name: String,
+            }
+        };
+        let analysis = Analysis::from(&input).unwrap();
+        let factory = FactoryCodegen::new(&analysis);
+
+        // Act
+        let generated = factory.generate_factory_method_make().to_string();
+
+        // Assert
+        assert!(
+            generated.contains("use :: fabrique :: fake :: Fake"),
+            "Should import Fake trait when custom faker is used. Generated: {}",
+            generated
+        );
+        assert!(
+            generated.contains("Name () . fake ()"),
+            "Should use custom faker expression. Generated: {}",
+            generated
+        );
+        assert!(
+            generated.contains("seeded_value :: < u32 >"),
+            "Fields without faker should use seeded_value. Generated: {}",
+            generated
+        );
+    }
 }

--- a/fabrique-derive/src/codegen/factory.rs
+++ b/fabrique-derive/src/codegen/factory.rs
@@ -42,6 +42,7 @@ impl<'a> FactoryCodegen<'a> {
         let factory_ident = &self.ident;
         let factory_fields = self.generate_factory_fields();
         let factory_method_new = self.generate_factory_method_new();
+        let factory_method_make = self.generate_factory_method_make();
         let factory_method_fields = self.generate_factory_method_fields();
         let factory_methods_for_relation = self.generate_factory_methods_for_relation();
         let factory_relation_fields = self.generate_factory_relation_fields();
@@ -86,6 +87,8 @@ impl<'a> FactoryCodegen<'a> {
 
             impl<DB: ::fabrique::Dialect> #factory_ident<DB> {
                 #factory_method_new
+
+                #factory_method_make
 
                 #(#factory_method_fields)*
 
@@ -364,6 +367,47 @@ impl<'a> FactoryCodegen<'a> {
                     #(#initialized_fields,)*
                     #(#initialized_relation_fields,)*
                     children: Vec::new(),
+                }
+            }
+        }
+    }
+
+    /// Generates the `make()` method that builds a model instance
+    /// without persisting it.
+    fn generate_factory_method_make(&self) -> TokenStream {
+        let struct_ident = &self.analysis.ident;
+
+        let has_custom_faker = self
+            .analysis
+            .column_fields
+            .iter()
+            .any(|f| f.faker.is_some());
+
+        let fake_import = if has_custom_faker {
+            quote! { use ::fabrique::fake::Fake; }
+        } else {
+            quote! {}
+        };
+
+        let column_fields = self.analysis.column_fields.iter().map(|field| {
+            let name = &field.ident;
+            let ty = &field.ty;
+
+            match &field.faker {
+                Some(faker_expr) => quote! {
+                    #name: self.#name.unwrap_or_else(|| #faker_expr.fake())
+                },
+                None => quote! {
+                    #name: self.#name.unwrap_or_else(::fabrique::seeded_value::<#ty>)
+                },
+            }
+        });
+
+        quote! {
+            pub fn make(self) -> #struct_ident {
+                #fake_import
+                #struct_ident {
+                    #(#column_fields,)*
                 }
             }
         }
@@ -658,6 +702,15 @@ mod tests {
                             weight: None,
                             hammer_relation: None,
                             children: Vec::new(),
+                        }
+                    }
+
+                    pub fn make(self) -> Anvil {
+                        Anvil {
+                            id: self.id.unwrap_or_else(::fabrique::seeded_value::<u32>),
+                            hammer_id: self.hammer_id.unwrap_or_else(::fabrique::seeded_value::<u32>),
+                            hardness: self.hardness.unwrap_or_else(::fabrique::seeded_value::<u32>),
+                            weight: self.weight.unwrap_or_else(::fabrique::seeded_value::<u32>),
                         }
                     }
 

--- a/fabrique-derive/src/codegen/persist.rs
+++ b/fabrique-derive/src/codegen/persist.rs
@@ -18,6 +18,7 @@ impl<'a> PersistCodegen<'a> {
         let base_struct_ident = &self.analysis.ident;
         let fn_create = self.generate_fn_create();
         let fn_save = self.generate_fn_save();
+        let fn_push_bind_values = self.generate_fn_push_bind_values();
 
         // Per-column-field Encode/Type bounds (using `as` type when present)
         let field_bounds = self.analysis.column_fields.iter().map(|f| {
@@ -38,6 +39,8 @@ impl<'a> PersistCodegen<'a> {
                 #fn_create
 
                 #fn_save
+
+                #fn_push_bind_values
             }
         }
     }
@@ -66,6 +69,29 @@ impl<'a> PersistCodegen<'a> {
                         .await
                         .map_err(Into::into)
                 }
+            }
+        }
+    }
+
+    /// Generates the `push_bind_values()` method.
+    fn generate_fn_push_bind_values(&self) -> TokenStream {
+        let base_struct_ident = &self.analysis.ident;
+        let bind_calls = self.analysis.column_fields.iter().map(|field| {
+            let ident = &field.ident;
+            let column_type = &field.column_type;
+            quote! {
+                separated.push_bind(
+                    <#column_type as ::fabrique::Column<#base_struct_ident>>::into_db(self.#ident)
+                );
+            }
+        });
+
+        quote! {
+            fn push_bind_values(
+                self,
+                mut separated: ::sqlx::query_builder::Separated<'_, DB, &'static str>,
+            ) {
+                #(#bind_calls)*
             }
         }
     }
@@ -161,6 +187,15 @@ mod tests {
                                 .await
                                 .map_err(Into::into)
                         }
+                    }
+
+                    fn push_bind_values(
+                        self,
+                        mut separated: ::sqlx::query_builder::Separated<'_, DB, &'static str>,
+                    ) {
+                        separated.push_bind(
+                            <AnvilIdColumn as ::fabrique::Column<Anvil>>::into_db(self.id)
+                        );
                     }
                 }
             }

--- a/fabrique/src/lib.rs
+++ b/fabrique/src/lib.rs
@@ -88,6 +88,7 @@ pub use error::*;
 pub use factory::*;
 pub use model::*;
 pub use relation::*;
+pub use upsert::*;
 
 #[cfg(feature = "testing")]
 pub use fake;
@@ -117,6 +118,7 @@ pub mod model;
 pub mod prelude;
 pub mod relation;
 pub mod sql;
+pub mod upsert;
 #[cfg(feature = "testing")]
 #[doc(hidden)]
 pub use fabrique_core::__private;

--- a/fabrique/src/prelude.rs
+++ b/fabrique/src/prelude.rs
@@ -5,3 +5,4 @@ pub use crate::error::*;
 pub use crate::factory::*;
 pub use crate::model::*;
 pub use crate::relation::*;
+pub use crate::upsert::*;

--- a/fabrique/src/upsert.rs
+++ b/fabrique/src/upsert.rs
@@ -1,0 +1,1 @@
+pub use fabrique_core::upsert::*;

--- a/fabrique/tests/upsert.rs
+++ b/fabrique/tests/upsert.rs
@@ -83,3 +83,28 @@ async fn test_upsert_empty_vec_is_noop<DB: Dialect>(pool: Pool<DB>) {
     let all = Product::all(&pool).await.unwrap();
     assert_eq!(all.len(), 0);
 }
+
+#[fabrique::test]
+async fn test_upsert_with_tuples<DB: Dialect>(pool: Pool<DB>) {
+    let products = vec![
+        Product::factory::<DB>()
+            .name("Anvil 3000".to_owned())
+            .make(),
+        Product::factory::<DB>()
+            .name("Rocket Skates".to_owned())
+            .make(),
+    ];
+
+    let result = products.clone().upsert(&pool, (Product::ID,)).await;
+    assert!(result.is_ok());
+
+    let result = products
+        .clone()
+        .upsert(&pool, (Product::ID, Product::NAME))
+        .await;
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err().to_string(),
+        "database error: error returned from database: (code: 1) ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint"
+    );
+}

--- a/fabrique/tests/upsert.rs
+++ b/fabrique/tests/upsert.rs
@@ -103,8 +103,4 @@ async fn test_upsert_with_tuples<DB: Dialect>(pool: Pool<DB>) {
         .upsert(&pool, (Product::ID, Product::NAME))
         .await;
     assert!(result.is_err());
-    assert_eq!(
-        result.unwrap_err().to_string(),
-        "database error: error returned from database: (code: 1) ON CONFLICT clause does not match any PRIMARY KEY or UNIQUE constraint"
-    );
 }

--- a/fabrique/tests/upsert.rs
+++ b/fabrique/tests/upsert.rs
@@ -48,10 +48,6 @@ async fn test_upsert_updates_existing_records<DB: Dialect>(pool: Pool<DB>) {
     assert_eq!(all[0].price_cents, 4999);
 }
 
-// SQLite requires a UNIQUE index on the conflict target columns;
-// the test schema only has a PK on `id`, not a composite unique
-// on (name, price_cents).
-#[cfg(not(feature = "sqlite"))]
 #[fabrique::test]
 async fn test_upsert_with_composite_unique_by<DB: Dialect>(pool: Pool<DB>) {
     let products = vec![
@@ -89,18 +85,36 @@ async fn test_upsert_with_tuples<DB: Dialect>(pool: Pool<DB>) {
     let products = vec![
         Product::factory::<DB>()
             .name("Anvil 3000".to_owned())
+            .price_cents(100)
             .make(),
         Product::factory::<DB>()
             .name("Rocket Skates".to_owned())
+            .price_cents(200)
             .make(),
     ];
 
-    let result = products.clone().upsert(&pool, (Product::ID,)).await;
-    assert!(result.is_ok());
-
-    let result = products
+    // Arity 1: tuple with single column
+    products
         .clone()
-        .upsert(&pool, (Product::ID, Product::NAME))
-        .await;
-    assert!(result.is_err());
+        .upsert(&pool, (Product::ID,))
+        .await
+        .unwrap();
+
+    let all = Product::all(&pool).await.unwrap();
+    assert_eq!(all.len(), 2);
+
+    // Arity 2: tuple with composite unique (name, price_cents)
+    let updated = vec![Product {
+        in_stock: false,
+        ..products[0].clone()
+    }];
+    updated
+        .upsert(&pool, (Product::NAME, Product::PRICE_CENTS))
+        .await
+        .unwrap();
+
+    let all = Product::all(&pool).await.unwrap();
+    assert_eq!(all.len(), 2);
+    let anvil = all.iter().find(|p| p.name == "Anvil 3000").unwrap();
+    assert!(!anvil.in_stock);
 }

--- a/fabrique/tests/upsert.rs
+++ b/fabrique/tests/upsert.rs
@@ -1,0 +1,85 @@
+use fabrique::prelude::*;
+use uuid::Uuid;
+
+#[derive(Clone, Debug, Default, Factory, PartialEq, Model)]
+#[allow(dead_code)]
+pub struct Product {
+    pub id: Uuid,
+    pub name: String,
+    pub price_cents: i32,
+    pub in_stock: bool,
+}
+
+#[fabrique::test]
+async fn test_upsert_inserts_new_records<DB: Dialect>(pool: Pool<DB>) {
+    let products = vec![
+        Product::factory::<DB>()
+            .name("Anvil 3000".to_owned())
+            .make(),
+        Product::factory::<DB>()
+            .name("Rocket Skates".to_owned())
+            .make(),
+    ];
+
+    products.upsert(&pool, Product::ID).await.unwrap();
+
+    let all = Product::all(&pool).await.unwrap();
+    assert_eq!(all.len(), 2);
+}
+
+#[fabrique::test]
+async fn test_upsert_updates_existing_records<DB: Dialect>(pool: Pool<DB>) {
+    let product = Product::factory()
+        .name("Anvil 3000".to_owned())
+        .price_cents(9999)
+        .create(&pool)
+        .await
+        .unwrap();
+
+    let updated = vec![Product {
+        price_cents: 4999,
+        ..product
+    }];
+
+    updated.upsert(&pool, Product::ID).await.unwrap();
+
+    let all = Product::all(&pool).await.unwrap();
+    assert_eq!(all.len(), 1);
+    assert_eq!(all[0].price_cents, 4999);
+}
+
+// SQLite requires a UNIQUE index on the conflict target columns;
+// the test schema only has a PK on `id`, not a composite unique
+// on (name, price_cents).
+#[cfg(not(feature = "sqlite"))]
+#[fabrique::test]
+async fn test_upsert_with_composite_unique_by<DB: Dialect>(pool: Pool<DB>) {
+    let products = vec![
+        Product::factory::<DB>()
+            .name("Anvil 3000".to_owned())
+            .price_cents(9999)
+            .make(),
+        Product::factory::<DB>()
+            .name("Anvil 3000".to_owned())
+            .price_cents(4999)
+            .make(),
+    ];
+
+    products
+        .upsert(&pool, (Product::NAME, Product::PRICE_CENTS))
+        .await
+        .unwrap();
+
+    let all = Product::all(&pool).await.unwrap();
+    assert_eq!(all.len(), 2);
+}
+
+#[fabrique::test]
+async fn test_upsert_empty_vec_is_noop<DB: Dialect>(pool: Pool<DB>) {
+    let products: Vec<Product> = vec![];
+
+    products.upsert(&pool, Product::ID).await.unwrap();
+
+    let all = Product::all(&pool).await.unwrap();
+    assert_eq!(all.len(), 0);
+}

--- a/migrations/mysql/00001_initial_schema.sql
+++ b/migrations/mysql/00001_initial_schema.sql
@@ -20,7 +20,8 @@ CREATE TABLE products (
     name VARCHAR(255) NOT NULL,
     price_cents INTEGER NOT NULL,
     in_stock BOOLEAN NOT NULL DEFAULT true,
-    deleted_at DATETIME
+    deleted_at DATETIME,
+    UNIQUE (name, price_cents)
 );
 
 CREATE TABLE orders (

--- a/migrations/postgres/00001_initial_schema.sql
+++ b/migrations/postgres/00001_initial_schema.sql
@@ -19,7 +19,8 @@ CREATE TABLE products (
     name VARCHAR(255) NOT NULL,
     price_cents INTEGER NOT NULL,
     in_stock BOOLEAN NOT NULL DEFAULT true,
-    deleted_at TIMESTAMPTZ
+    deleted_at TIMESTAMPTZ,
+    UNIQUE (name, price_cents)
 );
 
 CREATE TABLE orders (

--- a/migrations/sqlite/00001_initial_schema.sql
+++ b/migrations/sqlite/00001_initial_schema.sql
@@ -21,7 +21,8 @@ CREATE TABLE products (
     name TEXT NOT NULL,
     price_cents INTEGER NOT NULL,
     in_stock BOOLEAN NOT NULL DEFAULT 1,
-    deleted_at TEXT
+    deleted_at TEXT,
+    UNIQUE (name, price_cents)
 );
 
 CREATE TABLE orders (


### PR DESCRIPTION
resolves #136 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added .make() to build model instances in memory and .upsert() for bulk insert/update with configurable conflict keys.

* **Documentation**
  * New docs and cookbook examples for building without persisting and bulk upsert usage, conflict-key guidance, and examples.

* **Tests**
  * Added upsert tests covering inserts, updates, composite keys, tuple conflict targets, and empty-collection no-op.

* **Database Migrations**
  * Added composite unique constraint on (name, price_cents) for products.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->