### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/robinstraub/fabrique/compare/fabrique-v0.3.1...fabrique-v0.4.0) - 2026-06-10
+
+### Added
+
+- add upsert method ([#137](https://github.com/robinstraub/fabrique/pull/137))
+
 ## [0.3.1](https://github.com/robinstraub/fabrique/compare/fabrique-v0.2.2...fabrique-v0.3.1) - 2026-02-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "fabrique"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "cargo-husky",
  "chrono",
@@ -445,7 +445,7 @@ dependencies = [
 
 [[package]]
 name = "fabrique-core"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "fabrique",
  "fabrique-derive",
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "fabrique-derive"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "darling 0.21.3",
  "fabrique",

--- a/fabrique-core/Cargo.toml
+++ b/fabrique-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fabrique-core"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 description = "Core traits and types for Fabrique"
 license = "MIT"

--- a/fabrique-derive/Cargo.toml
+++ b/fabrique-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fabrique-derive"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 description = "Derive macros for Fabrique"
 license = "MIT"
@@ -22,7 +22,7 @@ proc-macro = true
 
 [dependencies]
 darling = "0.21"
-fabrique-core = { path = "../fabrique-core", version = "0.3.1" }
+fabrique-core = { path = "../fabrique-core", version = "0.4.0" }
 heck = "0.5"
 pluralizer = "0.4"
 proc-macro2 = "1.0"

--- a/fabrique/Cargo.toml
+++ b/fabrique/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fabrique"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 description = "SQL-first, type-safe, ergonomic database toolkit for Rust"
 license = "MIT"
@@ -19,8 +19,8 @@ mysql = ["fabrique-core/mysql", "fabrique-derive/mysql"]
 sqlite = ["fabrique-core/sqlite", "fabrique-derive/sqlite"]
 
 [dependencies]
-fabrique-core = { path = "../fabrique-core", version = "0.3.1" }
-fabrique-derive = { path = "../fabrique-derive", version = "0.3.1" }
+fabrique-core = { path = "../fabrique-core", version = "0.4.0" }
+fabrique-derive = { path = "../fabrique-derive", version = "0.4.0" }
 fake = { workspace = true, optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION



## 🤖 New release

* `fabrique-core`: 0.3.1 -> 0.4.0 (⚠ API breaking changes)
* `fabrique-derive`: 0.3.1 -> 0.4.0
* `fabrique`: 0.3.1 -> 0.4.0 (✓ API compatible changes)

### ⚠ `fabrique-core` breaking changes

```text
--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_method_added.ron

Failed in:
  trait method fabrique_core::model::Persist::push_bind_values in file /tmp/.tmpzGNdy5/fabrique/fabrique-core/src/model.rs:122
```

<details><summary><i><b>Changelog</b></i></summary><p>



## `fabrique`

<blockquote>

## [0.4.0](https://github.com/robinstraub/fabrique/compare/fabrique-v0.3.1...fabrique-v0.4.0) - 2026-06-10

### Added

- add upsert method ([#137](https://github.com/robinstraub/fabrique/pull/137))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).